### PR TITLE
Add AI analysis report modal with charts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,9 @@ dmypy.json
 ehthumbs.db
 Thumbs.db
 
+# JavaScript
+node_modules/
+
 # Project specific
 *.pdf
 *.csv

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,8 +16,14 @@
         "react-dom": "^18.2.0",
         "react-dropzone": "^14.2.0",
         "react-scripts": "5.0.1",
+        "recharts": "^2.8.0",
         "typescript": "^4.9.0",
         "web-vitals": "^3.0.0"
+      },
+      "devDependencies": {
+        "autoprefixer": "^10.4.16",
+        "postcss": "^8.4.31",
+        "tailwindcss": "^3.3.5"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -3513,6 +3519,69 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/eslint": {
       "version": "8.56.12",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.12.tgz",
@@ -5578,6 +5647,15 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -6308,6 +6386,127 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -6400,6 +6599,12 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/dedent": {
@@ -6617,6 +6822,16 @@
       "license": "MIT",
       "dependencies": {
         "utila": "~0.4"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/dom-serializer": {
@@ -7825,6 +8040,15 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.2.2.tgz",
+      "integrity": "sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -9181,6 +9405,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ipaddr.js": {
@@ -13943,6 +14176,37 @@
         }
       }
     },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -13977,6 +14241,44 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
+      "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/recharts/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
     },
     "node_modules/recursive-readdir": {
       "version": "2.2.3",
@@ -16014,6 +16316,12 @@
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "license": "MIT"
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -16528,6 +16836,28 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/w3c-hr-time": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,13 @@
     "typescript": "^4.9.0",
     "web-vitals": "^3.0.0",
     "axios": "^1.6.0",
-    "react-dropzone": "^14.2.0"
+    "react-dropzone": "^14.2.0",
+    "recharts": "^2.8.0"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.3.5"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/src/SimpleApp.tsx
+++ b/frontend/src/SimpleApp.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { simpleApiService, ProcessingResult, Transaction, AnalyzeResponse } from './services/simpleApi';
+import AnalysisReportModal from './components/AnalysisReportModal';
 import styles from './App.module.css';
 
 enum AppState {
@@ -19,6 +20,7 @@ const SimpleApp: React.FC = () => {
   // AI Analysis state
   const [aiAnalysis, setAiAnalysis] = useState<AnalyzeResponse | null>(null);
   const [isAnalyzing, setIsAnalyzing] = useState<boolean>(false);
+  const [isReportOpen, setIsReportOpen] = useState<boolean>(false);
 
   const handleFileSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
@@ -64,6 +66,7 @@ const SimpleApp: React.FC = () => {
     setPassword('');
     setAiAnalysis(null);
     setIsAnalyzing(false);
+    setIsReportOpen(false);
   };
 
   const handleAnalyzeWithAI = async (provider: string = 'mock') => {
@@ -237,8 +240,8 @@ const SimpleApp: React.FC = () => {
           </div>
         )}
 
-        {appState === AppState.RESULTS && results?.success && results.transactions && (
-          <div className={styles.resultsSection}>
+      {appState === AppState.RESULTS && results?.success && results.transactions && (
+        <div className={styles.resultsSection}>
             <div className={styles.card}>
               <h2>✅ Processing Complete!</h2>
               <div className={styles.resultsSummary}>
@@ -273,6 +276,19 @@ const SimpleApp: React.FC = () => {
                     </div>
                   </div>
                 )}
+                <div className="mt-4 rounded-lg border border-slate-200 bg-white/70 p-4 shadow-sm">
+                  <h5 className="text-sm font-semibold text-slate-700">Need a deeper dive?</h5>
+                  <p className="mt-1 text-xs text-slate-500">
+                    View charts and AI-generated insights summarizing your spending habits.
+                  </p>
+                  <button
+                    onClick={() => setIsReportOpen(true)}
+                    disabled={!results.transactions?.length}
+                    className="mt-3 inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:ring-offset-2 disabled:cursor-not-allowed disabled:bg-slate-300"
+                  >
+                    📊 Analysis Report
+                  </button>
+                </div>
               </div>
 
               <div className={styles.transactionsTable}>
@@ -355,6 +371,15 @@ const SimpleApp: React.FC = () => {
           </div>
         )}
       </main>
+
+      {appState === AppState.RESULTS && (
+        <AnalysisReportModal
+          isOpen={isReportOpen}
+          onClose={() => setIsReportOpen(false)}
+          transactions={results?.transactions || []}
+          aiAnalysis={aiAnalysis}
+        />
+      )}
     </div>
   );
 };

--- a/frontend/src/components/AnalysisReportModal.tsx
+++ b/frontend/src/components/AnalysisReportModal.tsx
@@ -1,0 +1,234 @@
+import React, { useMemo } from 'react';
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  PieChart,
+  Pie,
+  Cell,
+  Legend
+} from 'recharts';
+import { AnalyzeResponse, Transaction } from '../services/simpleApi';
+
+interface AnalysisReportModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  transactions: Transaction[];
+  aiAnalysis: AnalyzeResponse | null;
+}
+
+interface InsightSummary {
+  pros: string[];
+  cons: string[];
+  recommendations: string[];
+}
+
+const COLORS = ['#0ea5e9', '#a855f7', '#f97316', '#22c55e', '#ef4444', '#14b8a6'];
+
+const formatDateLabel = (dateStr: string) => {
+  const date = new Date(dateStr);
+  if (Number.isNaN(date.getTime())) {
+    return dateStr;
+  }
+  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+};
+
+const generateFallbackInsights = (transactions: Transaction[]): InsightSummary => {
+  const totalIncome = transactions.reduce((sum, txn) => sum + (txn.credit || 0), 0);
+  const totalExpense = transactions.reduce((sum, txn) => sum + (txn.debit || 0), 0);
+  const balanceTrend = totalIncome - totalExpense;
+
+  const pros: string[] = [];
+  const cons: string[] = [];
+  const recommendations: string[] = [];
+
+  if (totalIncome > 0) {
+    pros.push(`Consistent income inflow of ${totalIncome.toFixed(2)} detected.`);
+  }
+  if (totalExpense < totalIncome) {
+    pros.push('Spending is within your income range, indicating positive cash flow.');
+  }
+
+  if (totalExpense > totalIncome) {
+    cons.push('Expenses exceed income which could lead to negative cash flow.');
+    recommendations.push('Review discretionary spending categories and set monthly limits.');
+  }
+
+  const highestExpense = transactions.reduce<{ category: string; amount: number } | null>((highest, txn) => {
+    const amount = txn.debit || 0;
+    if (!amount) return highest;
+    const category = txn.ai_category || txn.transaction_type || 'Others';
+    if (!highest || amount > highest.amount) {
+      return { category, amount };
+    }
+    return highest;
+  }, null);
+
+  if (highestExpense) {
+    recommendations.push(`Monitor spending in "${highestExpense.category}" which had the single highest transaction.`);
+  }
+
+  if (balanceTrend > 0) {
+    pros.push('You are saving more than you spend this period.');
+    recommendations.push('Consider allocating surplus funds to investments or an emergency fund.');
+  }
+
+  if (cons.length === 0) {
+    cons.push('No significant overspending patterns detected. Maintain current habits.');
+  }
+
+  if (recommendations.length === 0) {
+    recommendations.push('Continue tracking your expenses and set category-based budgets to stay on course.');
+  }
+
+  return { pros, cons, recommendations };
+};
+
+const AnalysisReportModal: React.FC<AnalysisReportModalProps> = ({
+  isOpen,
+  onClose,
+  transactions,
+  aiAnalysis
+}) => {
+  const spendingByDate = useMemo(() => {
+    const aggregation = transactions.reduce<Record<string, number>>((acc, txn) => {
+      if (!txn.date) return acc;
+      const dateKey = new Date(txn.date).toISOString().slice(0, 10);
+      const amount = txn.debit || 0;
+      acc[dateKey] = (acc[dateKey] || 0) + amount;
+      return acc;
+    }, {});
+
+    return Object.entries(aggregation)
+      .map(([date, amount]) => ({ date, amount: Number(amount.toFixed(2)) }))
+      .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+  }, [transactions]);
+
+  const spendingByCategory = useMemo(() => {
+    const aggregation = transactions.reduce<Record<string, number>>((acc, txn) => {
+      const category = txn.ai_category || txn.transaction_type || (txn.credit ? 'Income' : 'Others');
+      const amount = txn.debit || txn.credit || 0;
+      acc[category] = (acc[category] || 0) + amount;
+      return acc;
+    }, {});
+
+    return Object.entries(aggregation).map(([name, value]) => ({
+      name,
+      value: Number(value.toFixed(2))
+    }));
+  }, [transactions]);
+
+  const insightSummary: InsightSummary = useMemo(() => {
+    if (aiAnalysis?.insights) {
+      return aiAnalysis.insights;
+    }
+    return generateFallbackInsights(transactions);
+  }, [aiAnalysis, transactions]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4">
+      <div className="w-full max-w-4xl rounded-xl bg-white shadow-2xl">
+        <div className="flex items-center justify-between border-b border-slate-200 px-6 py-4">
+          <h3 className="text-xl font-semibold text-slate-900">AI Analysis Report</h3>
+          <button
+            onClick={onClose}
+            className="rounded-full border border-slate-200 px-3 py-1 text-sm font-medium text-slate-600 transition hover:bg-slate-100"
+          >
+            Close
+          </button>
+        </div>
+
+        <div className="grid gap-6 px-6 py-6 md:grid-cols-2">
+          <div className="rounded-lg border border-slate-200 bg-slate-50 p-4">
+            <h4 className="mb-3 text-base font-semibold text-slate-800">Daily Expenditure</h4>
+            {spendingByDate.length > 0 ? (
+              <ResponsiveContainer width="100%" height={260}>
+                <LineChart data={spendingByDate}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#cbd5f5" />
+                  <XAxis dataKey="date" tickFormatter={formatDateLabel} tick={{ fill: '#475569' }} />
+                  <YAxis tick={{ fill: '#475569' }} />
+                  <Tooltip
+                    formatter={(value: number) => [`₹${value.toLocaleString()}`, 'Spent']}
+                    labelFormatter={(label) => formatDateLabel(label)}
+                  />
+                  <Line type="monotone" dataKey="amount" stroke="#2563eb" strokeWidth={3} dot={{ r: 3 }} />
+                </LineChart>
+              </ResponsiveContainer>
+            ) : (
+              <p className="text-sm text-slate-500">No expenditure data available.</p>
+            )}
+          </div>
+
+          <div className="rounded-lg border border-slate-200 bg-slate-50 p-4">
+            <h4 className="mb-3 text-base font-semibold text-slate-800">Spending by Category</h4>
+            {spendingByCategory.length > 0 ? (
+              <ResponsiveContainer width="100%" height={260}>
+                <PieChart>
+                  <Pie data={spendingByCategory} dataKey="value" nameKey="name" cx="50%" cy="50%" outerRadius={100}>
+                    {spendingByCategory.map((entry, index) => (
+                      <Cell key={`cell-${entry.name}`} fill={COLORS[index % COLORS.length]} />
+                    ))}
+                  </Pie>
+                  <Tooltip
+                    formatter={(value: number, name: string) => [`₹${Number(value).toLocaleString()}`, name]}
+                  />
+                  <Legend />
+                </PieChart>
+              </ResponsiveContainer>
+            ) : (
+              <p className="text-sm text-slate-500">No category data available.</p>
+            )}
+          </div>
+        </div>
+
+        <div className="border-t border-slate-200 bg-slate-50 px-6 py-6">
+          <div className="grid gap-6 md:grid-cols-3">
+            <div>
+              <h5 className="mb-2 text-sm font-semibold uppercase tracking-wide text-emerald-600">Pros</h5>
+              <ul className="space-y-2 text-sm text-slate-600">
+                {insightSummary.pros.map((item, index) => (
+                  <li key={index} className="flex items-start gap-2">
+                    <span className="mt-1 inline-flex h-2 w-2 flex-none rounded-full bg-emerald-400"></span>
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div>
+              <h5 className="mb-2 text-sm font-semibold uppercase tracking-wide text-rose-600">Cons</h5>
+              <ul className="space-y-2 text-sm text-slate-600">
+                {insightSummary.cons.map((item, index) => (
+                  <li key={index} className="flex items-start gap-2">
+                    <span className="mt-1 inline-flex h-2 w-2 flex-none rounded-full bg-rose-400"></span>
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div>
+              <h5 className="mb-2 text-sm font-semibold uppercase tracking-wide text-indigo-600">Recommendations</h5>
+              <ul className="space-y-2 text-sm text-slate-600">
+                {insightSummary.recommendations.map((item, index) => (
+                  <li key={index} className="flex items-start gap-2">
+                    <span className="mt-1 inline-flex h-2 w-2 flex-none rounded-full bg-indigo-400"></span>
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AnalysisReportModal;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-slate-100 font-sans text-slate-900;
+}

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import SimpleApp from './SimpleApp';
+import './index.css';
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement

--- a/frontend/src/services/simpleApi.ts
+++ b/frontend/src/services/simpleApi.ts
@@ -36,6 +36,12 @@ export interface AnalyzeRequest {
   provider?: string;
 }
 
+export interface InsightSummary {
+  pros: string[];
+  cons: string[];
+  recommendations: string[];
+}
+
 export interface AnalyzeResponse {
   success: boolean;
   categories: { [key: string]: CategoryResult };
@@ -50,6 +56,7 @@ export interface AnalyzeResponse {
     }>;
     provider_used: string;
   };
+  insights?: InsightSummary;
   error?: string;
 }
 

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,12 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./src/**/*.{js,jsx,ts,tsx}'],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ['"Inter"', 'system-ui', 'sans-serif']
+      }
+    }
+  },
+  plugins: []
+};


### PR DESCRIPTION
## Summary
- add an AI analysis report modal with daily spending and category charts powered by Recharts
- surface AI insight summaries with pros, cons, and recommendations alongside Tailwind-styled call to action
- configure Tailwind CSS pipeline and import new styles for the frontend build

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d14bcc9c608329a93dcae31fc4bd9a