### PR TITLE
Add shared bank statement processor module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ downloads/
 eggs/
 .eggs/
 lib/
+!src/lib/
+!src/lib/**
 lib64/
 parts/
 sdist/

--- a/src/api/jobs.py
+++ b/src/api/jobs.py
@@ -6,7 +6,6 @@ import os
 import tempfile
 from datetime import datetime
 from typing import Dict, Optional, Any
-from pathlib import Path
 import logging
 
 from .models import JobStatus, ProgressUpdate
@@ -23,8 +22,8 @@ class JobManager:
     """Manages processing jobs and their lifecycle."""
     
     def __init__(self):
-        self.processor = BankStatementProcessor()
         self.temp_dir = tempfile.mkdtemp(prefix="bank_processor_")
+        self.processor = BankStatementProcessor(output_dir=self.temp_dir)
     
     def create_job(self, filename: str, file_size: int) -> str:
         """Create a new job entry."""
@@ -43,6 +42,7 @@ class JobManager:
             'transactions': [],
             'csv_path': None,
             'bank_name': '',
+            'account_number': None,
             'processing_time': None
         }
         
@@ -106,7 +106,9 @@ class JobManager:
                 csv_path = await loop.run_in_executor(
                     None,
                     self.processor.export_to_csv,
-                    result['transactions']
+                    result['transactions'],
+                    result['bank'],
+                    result.get('account_number')
                 )
                 
                 # Update job with results
@@ -118,9 +120,10 @@ class JobManager:
                     'progress': 100,
                     'message': f'Processing completed. Found {result["count"]} transactions.',
                     'completed_at': end_time,
-                    'transactions': result['transactions'],
+                    'transactions': result['transactions_data'],
                     'csv_path': csv_path,
                     'bank_name': result['bank'],
+                    'account_number': result.get('account_number'),
                     'processing_time': processing_time
                 })
                 
@@ -130,6 +133,8 @@ class JobManager:
                 jobs[job_id].update({
                     'status': JobStatus.FAILED,
                     'error': result.get('error', 'Processing failed'),
+                    'error_type': result.get('error_type'),
+                    'error_details': result.get('details'),
                     'completed_at': datetime.utcnow()
                 })
                 self.update_progress(job_id, 0, "Processing failed", JobStatus.FAILED)
@@ -157,13 +162,18 @@ class JobManager:
             self.update_progress(job_id, 30, "Reading PDF file...")
             
             result = self.processor.process_pdf(pdf_path, password)
-            
-            self.update_progress(job_id, 70, f"Extracted {result['count']} transactions...")
-            
+
+            if result.get('status') == 'success':
+                self.update_progress(job_id, 70, f"Extracted {result['count']} transactions...")
+
             return result
-            
+
         except Exception as e:
-            return {'status': 'error', 'error': str(e)}
+            return {
+                'status': 'error',
+                'error': str(e),
+                'error_type': e.__class__.__name__,
+            }
     
     def add_progress_callback(self, job_id: str, callback):
         """Add a WebSocket callback for progress updates."""

--- a/src/lib/__init__.py
+++ b/src/lib/__init__.py
@@ -1,0 +1,5 @@
+"""Library utilities for the Bank Statement Processor API."""
+
+from .api import BankStatementProcessor
+
+__all__ = ["BankStatementProcessor"]

--- a/src/lib/api.py
+++ b/src/lib/api.py
@@ -1,0 +1,163 @@
+"""Public API for orchestrating PDF processing and CSV export."""
+
+from __future__ import annotations
+
+import logging
+import tempfile
+from dataclasses import asdict
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from uuid import uuid4
+
+from ..core.exceptions import (
+    BankStatementProcessorError,
+    ExportError,
+    StatementLayoutError,
+)
+from ..exporters.csv_exporter import CSVExporter, CSVExportError
+from ..parsers.base_parser import Transaction, TransactionType
+from ..parsers.parser_factory import ParserFactory
+
+logger = logging.getLogger(__name__)
+
+
+class BankStatementProcessor:
+    """Coordinate PDF parsing and CSV export for bank statements."""
+
+    def __init__(self, output_dir: Optional[str] = None) -> None:
+        """Create a processor instance.
+
+        Args:
+            output_dir: Directory where CSV exports should be written.
+        """
+        self.output_dir = Path(output_dir) if output_dir else Path(
+            tempfile.mkdtemp(prefix="bank_processor_exports_")
+        )
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+    def process_pdf(self, pdf_path: str, password: Optional[str] = None) -> Dict[str, Any]:
+        """Parse a PDF bank statement and prepare structured data.
+
+        Args:
+            pdf_path: Path to the PDF file.
+            password: Optional password for encrypted PDFs.
+
+        Returns:
+            Dictionary containing processing results. On success the dictionary
+            includes the raw ``Transaction`` objects and JSON serialisable
+            versions for API responses. On failure a dictionary containing error
+            information is returned instead.
+        """
+        try:
+            parser = ParserFactory.create_parser(pdf_path, password)
+            transactions = parser.extract_transactions()
+
+            if not transactions:
+                raise StatementLayoutError(
+                    pdf_path=pdf_path,
+                    missing_elements=["transactions"],
+                    bank_name=getattr(parser, "bank_name", "Unknown"),
+                )
+
+            try:
+                account_number = parser.get_account_number()
+            except Exception:  # pragma: no cover - defensive
+                account_number = None
+
+            serialized_transactions = [
+                self._transaction_to_dict(transaction)
+                for transaction in transactions
+            ]
+
+            result: Dict[str, Any] = {
+                "status": "success",
+                "transactions": transactions,
+                "transactions_data": serialized_transactions,
+                "count": len(transactions),
+                "bank": getattr(parser, "bank_name", "Unknown"),
+                "account_number": account_number or "Unknown",
+            }
+
+            logger.debug(
+                "Processed %s with %d transactions using %s",
+                pdf_path,
+                result["count"],
+                parser.__class__.__name__,
+            )
+            return result
+
+        except BankStatementProcessorError as exc:
+            logger.error("Bank processing failed for %s: %s", pdf_path, exc)
+            return {
+                "status": "error",
+                "error": str(exc),
+                "error_type": exc.__class__.__name__,
+                "details": getattr(exc, "details", {}),
+            }
+        except Exception as exc:  # pragma: no cover - unexpected failure path
+            logger.exception("Unexpected error processing PDF %s", pdf_path)
+            return {
+                "status": "error",
+                "error": str(exc),
+                "error_type": exc.__class__.__name__,
+            }
+
+    def export_to_csv(
+        self,
+        transactions: List[Transaction],
+        bank_name: str,
+        account_number: Optional[str] = None,
+    ) -> str:
+        """Export transactions to a CSV file and return the file path."""
+        if not transactions:
+            raise ExportError(
+                export_path=str(self.output_dir),
+                export_format="CSV",
+                transaction_count=0,
+                original_error=None,
+            )
+
+        output_path = self.output_dir / f"transactions_{uuid4().hex}.csv"
+        exporter = CSVExporter(str(output_path))
+
+        try:
+            exporter.export_with_summary(
+                transactions=transactions,
+                bank_name=bank_name,
+                account_number=account_number or "Unknown",
+            )
+        except CSVExportError as exc:
+            raise ExportError(
+                export_path=str(output_path),
+                export_format="CSV",
+                transaction_count=len(transactions),
+                original_error=exc,
+            ) from exc
+
+        logger.debug("Exported %d transactions to %s", len(transactions), output_path)
+        return str(output_path)
+
+    @staticmethod
+    def _transaction_to_dict(transaction: Transaction) -> Dict[str, Any]:
+        """Convert a transaction dataclass to a JSON-friendly dictionary."""
+        transaction_dict = asdict(transaction)
+
+        date_value = transaction_dict.get("date")
+        if isinstance(date_value, datetime):
+            transaction_dict["date"] = date_value.isoformat()
+        elif date_value is not None:
+            transaction_dict["date"] = str(date_value)
+
+        txn_type = transaction_dict.get("transaction_type")
+        if isinstance(txn_type, TransactionType):
+            transaction_dict["transaction_type"] = txn_type.value
+        elif txn_type is not None:
+            transaction_dict["transaction_type"] = str(txn_type)
+
+        for key in ("debit", "credit", "balance"):
+            value = transaction_dict.get(key)
+            if value is not None:
+                transaction_dict[key] = float(value)
+
+        return transaction_dict

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,0 +1,95 @@
+"""Tests for the asynchronous job manager and FastAPI bootstrap."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from pathlib import Path
+
+
+from src.api.jobs import JobManager, JobStatus, jobs
+from src.api.main import app
+from src.parsers.base_parser import Transaction, TransactionType
+
+
+def test_job_manager_process_flow(monkeypatch, tmp_path):
+    """Ensure the job manager completes a mocked processing workflow."""
+
+    transactions = [
+        Transaction(
+            date=datetime(2024, 1, 1),
+            description="Salary",
+            reference="PAY123",
+            debit=None,
+            credit=1000.0,
+            balance=1000.0,
+            transaction_type=TransactionType.DEPOSIT,
+            counterparty="Acme Corp",
+            bank_name="Test Bank",
+            account_number="XXXX1234",
+        )
+    ]
+
+    serialized_transactions = [
+        {
+            'date': transactions[0].date.isoformat(),
+            'description': transactions[0].description,
+            'reference': transactions[0].reference,
+            'debit': transactions[0].debit,
+            'credit': transactions[0].credit,
+            'balance': transactions[0].balance,
+            'transaction_type': transactions[0].transaction_type.value,
+            'counterparty': transactions[0].counterparty,
+            'bank_name': transactions[0].bank_name,
+            'account_number': transactions[0].account_number,
+        }
+    ]
+
+    class DummyProcessor:
+        def __init__(self, output_dir: str | None = None) -> None:
+            self.output_dir = Path(output_dir) if output_dir else tmp_path
+            self.output_dir.mkdir(parents=True, exist_ok=True)
+
+        def process_pdf(self, pdf_path: str, password=None):
+            return {
+                'status': 'success',
+                'transactions': transactions,
+                'transactions_data': serialized_transactions,
+                'count': len(transactions),
+                'bank': 'Test Bank',
+                'account_number': 'XXXX1234',
+            }
+
+        def export_to_csv(self, txns, bank_name, account_number=None):
+            output_path = self.output_dir / 'output.csv'
+            output_path.write_text('id,amount\n1,1000\n', encoding='utf-8')
+            return str(output_path)
+
+    monkeypatch.setattr('src.api.jobs.BankStatementProcessor', DummyProcessor)
+
+    manager = JobManager()
+    job_id = manager.create_job('statement.pdf', 123)
+
+    pdf_path = tmp_path / 'statement.pdf'
+    pdf_path.write_text('dummy pdf content', encoding='utf-8')
+
+    asyncio.run(manager.process_job(job_id, str(pdf_path)))
+
+    job_data = manager.get_job(job_id)
+    assert job_data is not None
+    assert job_data['status'] == JobStatus.COMPLETED
+    assert job_data['bank_name'] == 'Test Bank'
+    assert job_data['transactions'] == serialized_transactions
+    assert Path(job_data['csv_path']).exists()
+
+    manager.cleanup_job(job_id)
+    assert job_id not in jobs
+
+
+def test_fastapi_app_startup():
+    """Verify the FastAPI application boots and exposes the root endpoint."""
+
+    routes = {route.path for route in app.router.routes}
+
+    assert "/" in routes
+    assert any(getattr(route, "name", "") == "root" for route in app.router.routes)


### PR DESCRIPTION
## Summary
- add a reusable `BankStatementProcessor` implementation in `src/lib/api.py`
- update the API job manager to use the shared processor and persist richer job metadata
- cover the processing flow and FastAPI app bootstrap with new tests

## Testing
- pytest tests/test_jobs.py

------
https://chatgpt.com/codex/tasks/task_e_68dd087434a08329b643e5bafb3c02d2