### PR TITLE
Ensure upload failures propagate failed status

### DIFF
--- a/frontend/src/components/FileUpload.tsx
+++ b/frontend/src/components/FileUpload.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useState } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { apiService } from '../services/api';
-import { UploadResponse } from '../types/api';
+import { UploadResponse, JobStatus } from '../types/api';
 import styles from './FileUpload.module.css';
 
 interface FileUploadProps {
@@ -45,6 +45,13 @@ const FileUpload: React.FC<FileUploadProps> = ({ onUploadSuccess, onError, disab
       }
 
       const response = await apiService.uploadFile(file);
+
+      if (response.status !== JobStatus.COMPLETED) {
+        const errorMessage = response.error || 'Processing failed. Please try another statement.';
+        onError(errorMessage);
+        return;
+      }
+
       onUploadSuccess(response);
     } catch (error: any) {
       onError(error.message || 'Upload failed');

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -10,6 +10,7 @@ export interface UploadResponse {
   filename: string;
   size: number;
   status: JobStatus;
+  error?: string;
 }
 
 export interface JobStatusResponse {

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,7 @@ websockets>=11.0.0
 # Testing
 pytest>=7.0.0
 pytest-cov>=4.0.0
+httpx>=0.24.0
 
 # Development dependencies
 black>=23.0.0

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -297,6 +297,9 @@ async def upload_file(
 
         logger.info(f"File uploaded successfully: {job_id}, size: {file_size}")
 
+        job_status = JobStatus.COMPLETED
+        error_message: Optional[str] = None
+
         # IMMEDIATELY PROCESS THE PDF using the working CLI parsers
         try:
             # Import the working parser - fix the import path
@@ -310,9 +313,12 @@ async def upload_file(
             bank_name = parser.bank_name if hasattr(parser, 'bank_name') else "Unknown"
 
             # Update job with processing results
-            job_manager.update_progress(job_id, 100,
-                                      f"Successfully processed {len(transactions)} transactions",
-                                      JobStatus.COMPLETED)
+            job_manager.update_progress(
+                job_id,
+                100,
+                f"Successfully processed {len(transactions)} transactions",
+                JobStatus.COMPLETED
+            )
 
             # Store transaction data in job
             job = job_manager.get_job(job_id)
@@ -337,18 +343,32 @@ async def upload_file(
             logger.info(f"Successfully processed {file.filename}: {len(transactions)} transactions from {bank_name}")
 
         except Exception as parse_error:
-            # If parsing fails, still return successful upload but mark job as failed
             logger.error(f"Failed to process PDF {file.filename}: {str(parse_error)}")
-            job_manager.update_progress(job_id, 0, f"Processing failed: {str(parse_error)}", JobStatus.FAILED)
+            error_message = f"Processing failed: {str(parse_error)}"
+            job_status = JobStatus.FAILED
+            job_manager.update_progress(job_id, 0, error_message, JobStatus.FAILED)
+
+            job = job_manager.get_job(job_id)
+            if job is not None:
+                job['error'] = error_message
 
         # Clean up temp file
         os.unlink(temp_file_path)
+
+        if job_status == JobStatus.FAILED:
+            return UploadResponse(
+                job_id=job_id,
+                filename=file.filename,
+                size=file_size,
+                status=job_status,
+                error=error_message
+            )
 
         return UploadResponse(
             job_id=job_id,
             filename=file.filename,
             size=file_size,
-            status=JobStatus.COMPLETED  # Return completed since we processed immediately
+            status=job_status
         )
 
     except Exception as e:

--- a/src/api/models.py
+++ b/src/api/models.py
@@ -20,6 +20,7 @@ class UploadResponse(BaseModel):
     filename: str = Field(..., description="Original filename")
     size: int = Field(..., description="File size in bytes")
     status: JobStatus = Field(default=JobStatus.PENDING)
+    error: Optional[str] = Field(None, description="Error message if processing failed")
 
 
 class JobStatusResponse(BaseModel):

--- a/tests/test_api_upload.py
+++ b/tests/test_api_upload.py
@@ -1,0 +1,135 @@
+"""Tests for the upload endpoint ensuring correct status reporting."""
+
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+# Provide a lightweight stub for the BankStatementProcessor dependency used by JobManager.
+lib_module = types.ModuleType("src.lib")
+lib_module.__path__ = []  # Mark as package
+api_module = types.ModuleType("src.lib.api")
+
+
+class _StubBankStatementProcessor:
+    def process_pdf(self, pdf_path: str, password: str | None = None):
+        return {
+            "status": "success",
+            "transactions": [],
+            "count": 0,
+            "bank": "Stub Bank",
+        }
+
+    def export_to_csv(self, transactions):  # pragma: no cover - not exercised in these tests
+        return "/tmp/stub.csv"
+
+
+api_module.BankStatementProcessor = _StubBankStatementProcessor
+setattr(lib_module, "api", api_module)
+sys.modules.setdefault("src.lib", lib_module)
+sys.modules.setdefault("src.lib.api", api_module)
+
+from src.api.auth import verify_token
+from src.api.jobs import job_manager, jobs, progress_callbacks
+from src.api.main import app
+from src.api.models import JobStatus
+from src.parsers import parser_factory
+
+
+@pytest.fixture(autouse=True)
+def reset_job_store():
+    """Ensure the in-memory job store is clean before and after each test."""
+    jobs.clear()
+    progress_callbacks.clear()
+    yield
+    jobs.clear()
+    progress_callbacks.clear()
+
+
+@pytest.fixture()
+def client():
+    """Return a FastAPI test client with authentication dependency overridden."""
+    app.dependency_overrides[verify_token] = lambda: "test-user"
+    with TestClient(app) as test_client:
+        yield test_client
+    app.dependency_overrides.pop(verify_token, None)
+
+
+def test_upload_file_success_sets_completed_status(client, monkeypatch):
+    """The endpoint should return COMPLETED only when parsing succeeds."""
+
+    class DummyParser:
+        bank_name = "Mock Bank"
+
+        def extract_transactions(self):
+            return [
+                SimpleNamespace(
+                    date="2024-01-01",
+                    description="Deposit",
+                    reference="REF123",
+                    debit=None,
+                    credit=150.0,
+                    balance=150.0,
+                    transaction_type="deposit",
+                    counterparty="Employer",
+                    bank_name="Mock Bank",
+                    account_number="****1234",
+                )
+            ]
+
+    def create_parser(_cls, _pdf_path, password=None):  # noqa: D401 - signature required for classmethod
+        return DummyParser()
+
+    monkeypatch.setattr(
+        parser_factory.ParserFactory,
+        "create_parser",
+        classmethod(create_parser),
+    )
+
+    response = client.post(
+        "/upload",
+        files={"file": ("statement.pdf", b"pdf data", "application/pdf")},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == JobStatus.COMPLETED.value
+    assert "error" not in data or data["error"] is None
+
+    job = job_manager.get_job(data["job_id"])
+    assert job is not None
+    assert job["status"] == JobStatus.COMPLETED
+    assert len(job["transactions"]) == 1
+
+
+def test_upload_file_failure_returns_failed_status(client, monkeypatch):
+    """If parsing fails, the endpoint should surface a FAILED status and error message."""
+
+    def failing_parser(_cls, _pdf_path, password=None):  # noqa: D401 - signature required for classmethod
+        raise RuntimeError("Unable to parse statement")
+
+    monkeypatch.setattr(
+        parser_factory.ParserFactory,
+        "create_parser",
+        classmethod(failing_parser),
+    )
+
+    response = client.post(
+        "/upload",
+        files={"file": ("broken.pdf", b"pdf data", "application/pdf")},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == JobStatus.FAILED.value
+    assert "Unable to parse" in data["error"]
+
+    job = job_manager.get_job(data["job_id"])
+    assert job is not None
+    assert job["status"] == JobStatus.FAILED
+    assert job["error"] is not None
+    assert "Unable to parse" in job["error"]
+


### PR DESCRIPTION
## Summary
- update the `/upload` handler to return `failed` responses with error details when parsing raises exceptions and record the error on the job
- extend the upload response schema plus frontend handling so failed uploads surface meaningful feedback to the user
- add targeted FastAPI tests for successful and failed uploads and include `httpx` as a test dependency

## Testing
- pytest tests/test_api_upload.py

------
https://chatgpt.com/codex/tasks/task_e_68dd0879ebc08329b9ceda122a12269c